### PR TITLE
Support Infrataster v0.3.0

### DIFF
--- a/infrataster-plugin-ssl_certificates.gemspec
+++ b/infrataster-plugin-ssl_certificates.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'infrataster', '~> 0.2.0'
+  spec.add_runtime_dependency 'infrataster', '~> 0.3.0'
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
I've noticed that Infrataster v0.3.0 has been released.
https://rubygems.org/gems/infrataster/versions/0.3.0

So I update gemspec.
